### PR TITLE
프로젝트 경로 기본값에서 side-project- prefix 제거

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ claude plugin install side-project-claude-code-plugin@side-project-claude-settin
 
 **`/init-project`가 묻는 것 (4가지):**
 1. 프로젝트 이름 (kebab-case)
-2. 프로젝트 경로 (기본 `~/side-project-{이름}`)
+2. 프로젝트 경로 (기본 `~/{이름}`)
 3. GitHub 공개 여부 (기본 private)
 4. 한 줄 설명
 

--- a/skills/init-project/SKILL.md
+++ b/skills/init-project/SKILL.md
@@ -52,7 +52,7 @@ gh --version
 사용자에게 다음 4가지를 물어본다 (AskUserQuestion 활용 가능):
 
 1. **프로젝트 이름** (kebab-case, 예: `my-workout-app`)
-2. **프로젝트 경로** (기본값: `~/side-project-{프로젝트이름}`)
+2. **프로젝트 경로** (기본값: `~/{프로젝트이름}`)
 3. **GitHub 레포 공개 여부** (`--public` / `--private`, 기본값: `--private`)
 4. **프로젝트 설명** (한 줄)
 


### PR DESCRIPTION
closes #42

## 변경
`~/side-project-{이름}` → `~/{이름}`

경로가 너무 길어지는 문제 해결.

## 변경 파일
- `skills/init-project/SKILL.md` Step 1
- `README.md` 첫 셋업 섹션

🤖 Generated with [Claude Code](https://claude.com/claude-code)