### PR TITLE
sync-blueprint workflow: concurrency + retry 추가

### DIFF
--- a/templates/.github/workflows/sync-blueprint.yml
+++ b/templates/.github/workflows/sync-blueprint.yml
@@ -11,6 +11,12 @@ on:
       - 'docs/ssot/product-blueprint.html'
   workflow_dispatch:  # 수동 트리거 허용
 
+# 동시 실행 방지 — 빠르게 연달아 push해도 순서대로 큐잉
+# cancel-in-progress: false → 진행 중인 sync를 중단하지 않고 완료 후 다음 실행
+concurrency:
+  group: blueprint-sync
+  cancel-in-progress: false
+
 jobs:
   sync:
     runs-on: ubuntu-latest
@@ -28,30 +34,60 @@ jobs:
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
 
-      - name: Push to public mirror
+      - name: Push to public mirror (with retry)
         env:
           GIT_SSH_COMMAND: "ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no"
+          SOURCE_SHA: ${{ github.sha }}
         run: |
-          git clone "git@github.com:${MIRROR_REPO}.git" /tmp/mirror
-          cp docs/ssot/product-blueprint.html /tmp/mirror/index.html
+          set -e
 
-          cd /tmp/mirror
-          git -c user.name="blueprint-sync-bot" \
-              -c user.email="blueprint-sync@noreply" \
-              add index.html
+          # GitHub Actions 일시 장애 대비 — 최대 3회, 30초 간격
+          MAX_ATTEMPTS=3
+          ATTEMPT=1
 
-          # 변경 없으면 조용히 종료
-          if git -c user.name="blueprint-sync-bot" \
-                 -c user.email="blueprint-sync@noreply" \
-                 diff --cached --quiet; then
-            echo "변경 없음 — 스킵"
-            exit 0
-          fi
+          while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
+            echo "=== Sync 시도 $ATTEMPT/$MAX_ATTEMPTS ==="
 
-          git -c user.name="blueprint-sync-bot" \
-              -c user.email="blueprint-sync@noreply" \
-              commit -m "Sync: blueprint from source (${GITHUB_SHA:0:7})"
-          git push
+            # 이전 시도의 잔재 정리
+            rm -rf /tmp/mirror
+
+            if git clone "git@github.com:${MIRROR_REPO}.git" /tmp/mirror \
+              && cp docs/ssot/product-blueprint.html /tmp/mirror/index.html \
+              && cd /tmp/mirror \
+              && git -c user.name="blueprint-sync-bot" \
+                     -c user.email="blueprint-sync@noreply" \
+                     add index.html; then
+
+              # 변경 없으면 조용히 성공
+              if git -c user.name="blueprint-sync-bot" \
+                     -c user.email="blueprint-sync@noreply" \
+                     diff --cached --quiet; then
+                echo "✅ 변경 없음 — 스킵"
+                exit 0
+              fi
+
+              if git -c user.name="blueprint-sync-bot" \
+                     -c user.email="blueprint-sync@noreply" \
+                     commit -m "Sync: blueprint from source (${SOURCE_SHA:0:7})" \
+                && git push; then
+                echo "✅ Sync 성공 (시도 $ATTEMPT)"
+                exit 0
+              fi
+            fi
+
+            cd - >/dev/null 2>&1 || true
+            echo "⚠️  Sync 실패 (시도 $ATTEMPT/$MAX_ATTEMPTS)"
+
+            if [ $ATTEMPT -lt $MAX_ATTEMPTS ]; then
+              echo "30초 후 재시도..."
+              sleep 30
+            fi
+
+            ATTEMPT=$((ATTEMPT + 1))
+          done
+
+          echo "❌ 최대 재시도 횟수 도달. 수동 re-run 필요"
+          exit 1
 
       - name: Cleanup
         if: always()


### PR DESCRIPTION
closes #46

## 변경
- `concurrency` 그룹 `blueprint-sync` 추가 (cancel-in-progress: false → 큐잉)
- push 단계에 bash retry (최대 3회, 30초 간격)
- 변경 없으면 early exit (불필요 commit 방지)
- third-party retry action 의존 X (supply chain risk 0)

## 깨지는 케이스 감소
Before → After

| 케이스 | Before | After |
|--------|--------|-------|
| GitHub Actions 일시 장애 | 실패 + 수동 re-run | 최대 3회 자동 재시도 |
| 동시 push 2건 | race로 한쪽 reject | 큐잉, 순차 실행 |

남은 깨짐 케이스: 사용자가 Deploy Key/secret/sync repo를 의도적으로 변경/삭제 + Actions disable + Pages 빌드 큐 지연(1-5분). 모두 사용자 귀책 또는 GitHub 인프라 지연.

## Test plan
- [x] YAML syntax valid (python yaml.safe_load 통과)
- [ ] 실제 sync repo에서 변경 push → workflow run 성공 확인
- [ ] 연달아 2회 push → 순차 실행 확인 (동시 아님)

🤖 Generated with [Claude Code](https://claude.com/claude-code)